### PR TITLE
Progress Bar V2

### DIFF
--- a/src/progress_bar_exercise/Button.js
+++ b/src/progress_bar_exercise/Button.js
@@ -1,4 +1,6 @@
 import React from "react";
+import PropTypes from 'prop-types';
+
 import "./Button.scss";
 
 const Button = ({ callback, className, label }) => {
@@ -7,6 +9,12 @@ const Button = ({ callback, className, label }) => {
       {label}
     </button>
   );
+};
+
+Button.propTypes = {
+  callback: PropTypes.func.isRequired,
+  className: PropTypes.string.isRequired,
+  label: PropTypes.string
 };
 
 export default Button;

--- a/src/progress_bar_exercise/ProgressBar.js
+++ b/src/progress_bar_exercise/ProgressBar.js
@@ -1,12 +1,17 @@
 import React from "react";
 import "./ProgressBar.scss";
 
-const ProgressBar = ({ requestStatus, percentageFilled }) => {
+import { calculateWidthByBreakpoints } from './utils/progressBarUtils';
+
+const ProgressBar = ({ requestStatus, percentageFilled, breakpoints }) => {
+
+  const calculatedWidth = breakpoints ? calculateWidthByBreakpoints(percentageFilled, breakpoints) : percentageFilled;
+
   return (
     <div className="canvas__progress-bar">
       <div
         className={`canvas__progress-indicator canvas__progress-indicator--${requestStatus}`}
-        style={{width: percentageFilled + '%'}}
+        style={{width: calculatedWidth + '%'}}
       />
     </div>
   );

--- a/src/progress_bar_exercise/ProgressBar.js
+++ b/src/progress_bar_exercise/ProgressBar.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from 'prop-types';
 import "./ProgressBar.scss";
 
 import { calculateWidthByBreakpoints } from './utils/progressBarUtils';
@@ -16,5 +17,11 @@ const ProgressBar = ({ requestStatus, percentageFilled, breakpoints }) => {
     </div>
   );
 }
+
+ProgressBar.propTypes = {
+  requestStatus: PropTypes.string.isRequired,
+  percentageFilled: PropTypes.number.isRequired,
+  breakpoints: PropTypes.arrayOf(PropTypes.number)
+};
 
 export default ProgressBar;

--- a/src/progress_bar_exercise/ProgressBarExercise.js
+++ b/src/progress_bar_exercise/ProgressBarExercise.js
@@ -1,10 +1,11 @@
-import React, { useCallback, useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import Exercise from "../exercise/Exercise";
 
 import Button from "./Button";
 import ProgressBar from "./ProgressBar";
 import { RequestStatus } from "./request-status";
 import useInterval from "./hooks/useInterval";
+import './ProgressBarExercise.scss';
 
 const ProgressBarExercise = () => {
   return (
@@ -28,6 +29,7 @@ const Solution = () => {
   const [timer, setTimer] = useState(null);
   const [progressBarFadeTimer, setProgressBarFadeTimer] = useState(null);
   const [delay, setDelay] = useState(null);
+  const [useBreakpoints, setUseBreakpoints] = useState(true);
 
   const DECREMENT = 100;
   const REQUEST_TIMER = 15000;
@@ -96,9 +98,16 @@ const Solution = () => {
     }
   }, [requestStatus, timer]);
 
+  const handleCheckboxCheck = () => {
+    setUseBreakpoints(!breakpoints);
+  };
+
+  // Sample breakpoints for the progress bar
+  const breakpoints = useBreakpoints ? [1,2,3,4,5,6,7,8,9,10,20,50,60,75,80,85,90,91,92,100] : null;
+
   return (
-    <div>
-      <ProgressBar requestStatus={requestStatus} percentageFilled={percentageFilled()} />
+    <div className="canvas">
+      <ProgressBar requestStatus={requestStatus} percentageFilled={percentageFilled()} breakpoints={breakpoints}/>
       <Button
         callback={() => handleStartClick()}
         className={`canvas__button canvas__request-button canvas__request-button--${requestStatus}`}
@@ -111,6 +120,15 @@ const Solution = () => {
           label="Finish Request"
         />
       }
+      <label>
+        Use Breakpoints
+      <input
+        className="canvas__checkbox"
+        checked={useBreakpoints}
+        onChange={() => handleCheckboxCheck()}
+        type="checkbox"
+      />
+      </label>
     </div>
   );
 };

--- a/src/progress_bar_exercise/ProgressBarExercise.scss
+++ b/src/progress_bar_exercise/ProgressBarExercise.scss
@@ -1,0 +1,9 @@
+$spiff-color: #1dc0a6; // Thank you, GIMP color picker
+
+.canvas > div, input, button {
+  margin: 3px;
+}
+
+label {
+  color: $spiff-color;
+}

--- a/src/progress_bar_exercise/tests/progressBarUtils.test.js
+++ b/src/progress_bar_exercise/tests/progressBarUtils.test.js
@@ -1,0 +1,45 @@
+import { calculateWidthByBreakpoints } from '../utils/progressBarUtils';
+
+describe('calculateWidthByBreakpoints', () => {
+    test('returns expected values given a normal ordered array', () => {
+        const breakpoints = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100];
+
+        for (let i = 0; i < 100; i++) {
+            let calculatedWidth = calculateWidthByBreakpoints(i, breakpoints);
+
+            if (calculatedWidth > 0) {
+                expect(breakpoints).toContain(calculatedWidth);
+            } else {
+                expect(calculatedWidth).toBe(0);
+            }
+        }
+    })
+
+    test('returns expected values given an unordered array', () => {
+        const breakpoints = [10, 20, 30, 22, 52, 21, 77, 99, 90, 100];
+
+        for (let i = 0; i < 100; i++) {
+            let calculatedWidth = calculateWidthByBreakpoints(i, breakpoints);
+
+            if (calculatedWidth > 0) {
+                expect(breakpoints).toContain(calculatedWidth);
+            } else {
+                expect(calculatedWidth).toBe(0);
+            }
+        }
+    })
+
+    test('returns expected values given an unordered bad array', () => {
+        const breakpoints = [-1, 10, 20, 30, 22, 52, 21, "seventy seven", 99, 90, 100];
+
+        for (let i = 0; i < 100; i++) {
+            let calculatedWidth = calculateWidthByBreakpoints(i, breakpoints);
+
+            if (calculatedWidth > 0) {
+                expect(breakpoints).toContain(calculatedWidth);
+            } else {
+                expect(calculatedWidth).toBe(0);
+            }
+        }
+    })
+});

--- a/src/progress_bar_exercise/utils/progressBarUtils.js
+++ b/src/progress_bar_exercise/utils/progressBarUtils.js
@@ -1,0 +1,13 @@
+const calculateWidthByBreakpoints = (percentageFilled, breakpoints) => {
+  let maxBreakpointHit = Math.max(...breakpoints.filter(num => num <= percentageFilled));
+  // Hacky fix to make sure the bar doesn't shoot out to infinity
+  if (isNaN(maxBreakpointHit) || maxBreakpointHit <= 0) {
+      return 0;
+  }
+
+  return maxBreakpointHit;
+}
+
+export {
+  calculateWidthByBreakpoints
+}


### PR DESCRIPTION
### Summary
Adds support for breakpoints and a toggle on the canvas that enables them. The requirements said to animate slower between the breakpoints, which I didn't fully understand. Should follow up to figure out if this works correctly.

### Testing
- There's a new util test. Run `npm run test` in the tests directory
- Start requests with the breakpoint toggle checked. The bar should move in a more "realistic" fashion instead of being linear.
- Turn off the breakpoint toggle. It should animate linearly again.
- PropTypes were added in this pull. Check the console and verify it's not complaining about anything missing.