### PR TITLE
V2 Parser exercise

### DIFF
--- a/src/parser_exercise/ParserExercise.js
+++ b/src/parser_exercise/ParserExercise.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import Exercise from "../exercise/Exercise";
 import Button from "./Button";
 import { parse } from './utils/parseUtils';
@@ -23,6 +23,7 @@ export default ParserExercise;
 const Solution = () => {
   const [phrase, setPhrase] = useState("");
   const [count, setCount] = useState({});
+  const [selectedCharacter, setSelectedCharacter] = useState("");
 
   // Parses the text area
   const handleParseClick = () => {
@@ -33,6 +34,11 @@ const Solution = () => {
   const resetTextArea = () => {
     setPhrase("");
     setCount({});
+    setSelectedCharacter("");
+  };
+
+  const handleCharacterClick = (character) => {
+    setSelectedCharacter(character);
   };
 
   // Will output on rerender (state change);
@@ -40,7 +46,7 @@ const Solution = () => {
     let output = [];
     for (const character in count) {
       output.push(
-        <div className="canvas__character">
+        <div onClick={() => handleCharacterClick(character)} className="canvas__character">
           <span className="canvas__character-key">{`${character}:`}</span>
           <span className="canvas__character-count">{`${count[character]}`}</span>
         </div>
@@ -60,6 +66,13 @@ const Solution = () => {
             value={phrase}
           />
         </div>
+        {selectedCharacter && phrase &&
+            <div 
+              className="canvas__highlighted-text"
+              // Aaaaack
+              dangerouslySetInnerHTML={{__html: phrase.replaceAll(selectedCharacter, '<span class="highlight">' + selectedCharacter + '</span>')}}
+            />
+        }
         <Button callback={() => handleParseClick()} label="Parse" className="canvas__button canvas__parse-button" />
         <Button callback={() => resetTextArea()} label="Reset" className="canvas__button canvas__reset-button" />
         {characterCounts()}

--- a/src/parser_exercise/ParserExercise.scss
+++ b/src/parser_exercise/ParserExercise.scss
@@ -2,6 +2,7 @@
     background-color: #f6f9fb;
     display: flex;
     flex-direction: column;
+    margin: 5px;
 }
 
 .canvas__character {
@@ -21,6 +22,10 @@ label, textarea {
 textarea {
     padding: 10px;
     max-width: 100%;
+}
+
+.highlight {
+  background-color: red;
 }
 
 label {

--- a/src/parser_exercise/tests/parseUtils.test.js
+++ b/src/parser_exercise/tests/parseUtils.test.js
@@ -5,8 +5,7 @@ describe('parse', () => {
     const phrase = "The quick brown fox jumps over the lazy dog";
     expect(parse(phrase)).toStrictEqual(
     {
-      " ": 8,
-      "T": 1,
+      "t": 2,
       "a": 1,
       "b": 1,
       "c": 1,
@@ -26,7 +25,6 @@ describe('parse', () => {
       "q": 1,
       "r": 2,
       "s": 1,
-      "t": 1,
       "u": 2,
       "v": 1,
       "w": 1,

--- a/src/parser_exercise/utils/parseUtils.js
+++ b/src/parser_exercise/utils/parseUtils.js
@@ -10,7 +10,14 @@ const parse = (phrase) => {
 
   let count = {};
 
+  // Make everything lower case
+  phrase = phrase.toLowerCase();
+
   for (const character of phrase) {
+    // Skip spaces
+    if (character === ' ') {
+      continue;
+    }
     if (count[character]) {
       count[character]++;
     } else {


### PR DESCRIPTION
### Summary
- Fixes a few quirks with the parser, such as only looking at characters regardless of case and removing spaces from the character count
- Lets you click the character in the count area to highlight the characters in a copy of the text area.

Note to reviewer: I wanted to make sure that I was able to submit this to you folks by the weekend, so I want to note that a few things aren't up to my standards when it comes to production code. That includes:
- CSS styling quality
- Commenting (particularly on functions)
- How the components actually look when rendered.
- Using `dangerouslySetInnerHTML` in general! Hah.

This pull request would be something more along the lines of a Work in Progress or "Please review/suggest changes while I continue to work on it" if I opened it on a Spiff codebase.

### Testing
- Click a character in the count area after parsing. The character should highlight in red. Spaces shouldn't be included.